### PR TITLE
Add compatibility for IE in intranet environments.

### DIFF
--- a/views/layouts/layout.handlebars
+++ b/views/layouts/layout.handlebars
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title>TIL</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
Added X-UA-Compatible meta tag so that the content of the app will render in the newest standards mode in internet explorer.  This should only be needed in intranet environments running IE.

:ghost: :jeans: 
